### PR TITLE
fix: onnxconverter-common probuf conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ tensorrt>=10.4.0 --extra-index-url https://pypi.nvidia.com
 onnx!=1.16.2
 onnx-graphsurgeon
 onnxmltools
-onnxconverter-common
+onnxconverter-common @ git+https://github.com/microsoft/onnxconverter-common.git@f7a8eb699caa6f6a78d3bdfbcaf5dfbd43569ebd
 pulp
 nvidia-modelopt[all] --extra-index-url https://pypi.nvidia.com


### PR DESCRIPTION
Updates pip requirements to install onnxconverter-common from the git repository instead of pypip.

An issue occurs with `onnxconverter-common` from pypip which pins `protobuf==3.20.2`, see https://github.com/microsoft/onnxconverter-common/issues/265. This has apparently been fixed in the latest version on github, but pypip hasn't been updated and leads to `protobuf==3.30.2` which breaks anything over `mediapipe==0.10.8`

```
pip install --upgrade mediapipe==0.10.20 leads to
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
onnxconverter-common 1.14.0 requires protobuf==3.20.2, but you have protobuf 4.25.6 which is incompatible.
```
After this change, protobuf installs to version `4.25.6` without issue. 

```
pip show protobuf
Name: protobuf
Version: 4.25.6
Summary: 
Home-page: https://developers.google.com/protocol-buffers/
Author: protobuf@googlegroups.com
Author-email: protobuf@googlegroups.com
License: 3-Clause BSD License
Location: /workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages
Requires: 
Required-by: comfyui, googleapis-common-protos, mediapipe, onnx, onnxconverter-common, onnxruntime-gpu, opentelemetry-prot
```

This change led to at least 50% performance improvement on a media pipe controlnet workflow.
Related PR for comfystream https://github.com/yondonfu/comfystream/pull/126/