### PR TITLE
Fix import error introduced by changes in `onnxmltools`

### DIFF
--- a/onnx_utils/export.py
+++ b/onnx_utils/export.py
@@ -12,7 +12,7 @@ import torch
 from modelopt.torch.quantization.nn import SequentialQuantizer, TensorQuantizer
 from onnx import numpy_helper
 from onnx.external_data_helper import _get_all_tensors, ExternalDataInfo
-from onnxmltools.utils.float16_converter import convert_float_to_float16
+from onnxconverter_common.float16 import convert_float_to_float16
 
 from .fp8_onnx_graphsurgeon import (
     cast_fp8_mha_io,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 tensorrt>=10.4.0 --extra-index-url https://pypi.nvidia.com
-onnx!=1.16.2
+onnx>=1.17.0
 onnx-graphsurgeon
-onnxmltools
 onnxconverter-common @ git+https://github.com/microsoft/onnxconverter-common.git@f7a8eb699caa6f6a78d3bdfbcaf5dfbd43569ebd
-pulp
-nvidia-modelopt[all] --extra-index-url https://pypi.nvidia.com
+nvidia-modelopt[torch] --extra-index-url https://pypi.nvidia.com
+diffusers>=0.32.2


### PR DESCRIPTION
[The commit](https://github.com/onnx/onnxmltools/commit/ccaf972e311d8cbb4577e89064268657c0d3a1ac#diff-da56886e1887630d9678ea7ac58a87e76d63b8056fe201a02b432f9edbebea6d) and subsequent `onnxmltools` release removed it's dependency on `onnxconverter_common` and `convert_float_to_float16` function that was re-exported from there. 

Here `onnxmltools` is being used only for that one function, so I removed the package from requirements and changed the import statement. 

Also, `nvidia-modelopt[all]` introduced **a lot** of extra dependencies, so I replaced it with `nvidia-modelopt[torch]` and appropriate version of `diffusers`.