### PR TITLE
onnxconverter-common>=1.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ tensorrt>=10.4.0 --extra-index-url https://pypi.nvidia.com
 onnx!=1.16.2
 onnx-graphsurgeon
 onnxmltools
-onnxconverter-common @ git+https://github.com/microsoft/onnxconverter-common.git@f7a8eb699caa6f6a78d3bdfbcaf5dfbd43569ebd
+onnxconverter-common>=1.15.0
 pulp
 nvidia-modelopt[all] --extra-index-url https://pypi.nvidia.com


### PR DESCRIPTION
Since [onnxconverter-common 1.15.0](https://github.com/microsoft/onnxconverter-common/releases/tag/v1.15.0) was released, the git commit patch from https://github.com/yondonfu/ComfyUI_TensorRT/pull/2 is no longer necessary